### PR TITLE
Add PGN export for search

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ iced_aw = { version = "0.11.0", default-features = false, features = ["tabs"] }
 iced_drop = {git = "https://github.com/jhannyj/iced_drop.git", rev="d259ec4dff098852d995d3bcaa5551a88330636f"}
 
 rand = "0.8.5"
+chrono = "0.4.41"
 chess = "3.2.0"
 csv = "1.3.1"
 serde = "1.0.217"

--- a/src/export.rs
+++ b/src/export.rs
@@ -353,27 +353,23 @@ pub fn to_pgn(puzzles: &Vec<config::Puzzle>, lang: &lang::Language, path: String
 
         // Add PGN headers
         pgn_content.push_str(&format!("[Event \"Chess Puzzle\"]\n"));
-        pgn_content.push_str(&format!("[Site \"Offline Puzzles\"]\n"));
+        pgn_content.push_str(&format!("[Site \"https://lichess.org/training/{}\"]\n", puzzle.puzzle_id));
         pgn_content.push_str(&format!("[Date \"{}\"]\n", chrono::Local::now().format("%Y.%m.%d")));
-        pgn_content.push_str(&format!("[Round \"{}\"]\n", puzzle_index + 1));
         pgn_content.push_str(&format!("[White \"{}\"]\n", if board.side_to_move() == Color::White { "Player" } else { "Opponent" }));
         pgn_content.push_str(&format!("[Black \"{}\"]\n", if board.side_to_move() == Color::Black { "Player" } else { "Opponent" }));
         pgn_content.push_str(&format!("[Result \"*\"]\n"));
+        pgn_content.push_str(&format!("[GameID \"{}\"]\n", puzzle.game_url));
         pgn_content.push_str(&format!("[FEN \"{}\"]\n", puzzle.fen));
         pgn_content.push_str(&format!("[SetUp \"1\"]\n"));
-
+        if !puzzle.opening.is_empty() {
+            pgn_content.push_str(&format!("[Opening \"{}\"]\n", puzzle.opening));
+        }
         // Add puzzle details
-        pgn_content.push_str(&format!("[PuzzleID \"{}\"]\n", puzzle.puzzle_id));
         pgn_content.push_str(&format!("[PuzzleRating \"{}\"]\n", puzzle.rating));
-        pgn_content.push_str(&format!("[PuzzleURL \"https://lichess.org/training/{}\"]\n", puzzle.puzzle_id));
         pgn_content.push_str(&format!("[PuzzleRatingDeviation \"{}\"]\n", puzzle.rating_deviation));
         pgn_content.push_str(&format!("[PuzzlePopularity \"{}\"]\n", puzzle.popularity));
         pgn_content.push_str(&format!("[PuzzleNbPlays \"{}\"]\n", puzzle.nb_plays));
         pgn_content.push_str(&format!("[PuzzleThemes \"{}\"]\n", puzzle.themes));
-        if !puzzle.opening.is_empty() {
-            pgn_content.push_str(&format!("[PuzzleOpening \"{}\"]\n", puzzle.opening));
-        }
-        pgn_content.push_str(&format!("[GameURL \"{}\"]\n", puzzle.game_url));
 
         // Start the move list
         let puzzle_moves: Vec<&str> = puzzle.moves.split_whitespace().collect();

--- a/src/export.rs
+++ b/src/export.rs
@@ -365,6 +365,15 @@ pub fn to_pgn(puzzles: &Vec<config::Puzzle>, lang: &lang::Language, path: String
         // Add puzzle details
         pgn_content.push_str(&format!("[PuzzleID \"{}\"]\n", puzzle.puzzle_id));
         pgn_content.push_str(&format!("[PuzzleRating \"{}\"]\n", puzzle.rating));
+        pgn_content.push_str(&format!("[PuzzleURL \"https://lichess.org/training/{}\"]\n", puzzle.puzzle_id));
+        pgn_content.push_str(&format!("[PuzzleRatingDeviation \"{}\"]\n", puzzle.rating_deviation));
+        pgn_content.push_str(&format!("[PuzzlePopularity \"{}\"]\n", puzzle.popularity));
+        pgn_content.push_str(&format!("[PuzzleNbPlays \"{}\"]\n", puzzle.nb_plays));
+        pgn_content.push_str(&format!("[PuzzleThemes \"{}\"]\n", puzzle.themes));
+        if !puzzle.opening.is_empty() {
+            pgn_content.push_str(&format!("[PuzzleOpening \"{}\"]\n", puzzle.opening));
+        }
+        pgn_content.push_str(&format!("[GameURL \"{}\"]\n", puzzle.game_url));
 
         // Start the move list
         let puzzle_moves: Vec<&str> = puzzle.moves.split_whitespace().collect();
@@ -424,13 +433,4 @@ pub fn to_pgn(puzzles: &Vec<config::Puzzle>, lang: &lang::Language, path: String
     // Write to file
     std::fs::write(path, pgn_content).expect("Unable to write PGN file");
 }
-        pgn_content.push_str(&format!("[PuzzleURL \"https://lichess.org/training/{}\"]\n", puzzle.puzzle_id));
-        pgn_content.push_str(&format!("[PuzzleRatingDeviation \"{}\"]\n", puzzle.rating_deviation));
-        pgn_content.push_str(&format!("[PuzzlePopularity \"{}\"]\n", puzzle.popularity));
-        pgn_content.push_str(&format!("[PuzzleNbPlays \"{}\"]\n", puzzle.nb_plays));
-        pgn_content.push_str(&format!("[PuzzleThemes \"{}\"]\n", puzzle.themes));
-        if !puzzle.opening.is_empty() {
-            pgn_content.push_str(&format!("[PuzzleOpening \"{}\"]\n", puzzle.opening));
-        }
-        pgn_content.push_str(&format!("[GameURL \"{}\"]\n", puzzle.game_url));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,7 @@ pub enum Message {
     SaveScreenshot(Option<(Screenshot, String)>),
     ExportPDF(Option<String>),
     LoadPuzzle(Option<Vec<config::Puzzle>>),
+    ExportPGN(Option<String>),
     ChangeSettings(Option<config::OfflinePuzzlesConfig>),
     EventOccurred(iced::Event),
     StartEngine,
@@ -664,6 +665,11 @@ impl OfflinePuzzles {
             } (_, Message::ExportPDF(file_path)) => {
                 if let Some(file_path) = file_path {
                     export::to_pdf(&self.puzzle_tab.puzzles, self.settings_tab.export_pgs.parse::<i32>().unwrap(), &self.lang, file_path);
+                }
+                Task::none()
+            } (_, Message::ExportPGN(file_path)) => {
+                if let Some(file_path) = file_path {
+                    export::to_pgn(&self.puzzle_tab.puzzles, &self.lang, file_path);
                 }
                 Task::none()
             } (_, Message::EventOccurred(event)) => {

--- a/src/puzzles.rs
+++ b/src/puzzles.rs
@@ -14,6 +14,7 @@ pub enum PuzzleMessage {
     OpenLink(String),
     TakeScreenshot,
     ExportToPDF,
+    ExportToPGN
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -60,6 +61,8 @@ impl PuzzleTab {
                 iced::window::screenshot(self.window_id.unwrap()).map(Message::ScreenshotCreated)
             } PuzzleMessage::ExportToPDF => {
                 Task::perform(PuzzleTab::export(), Message::ExportPDF)
+            } PuzzleMessage::ExportToPGN => {
+                return Task::perform(PuzzleTab::export(), Message::ExportPGN);
             }
         }
     }
@@ -133,6 +136,7 @@ impl Tab for PuzzleTab {
                 ],
                 Button::new(Text::new(lang::tr(&self.lang, "screenshot"))).on_press(PuzzleMessage::TakeScreenshot),
                 Button::new(Text::new(lang::tr(&self.lang, "export_pdf_btn"))).on_press(PuzzleMessage::ExportToPDF),
+                Button::new(Text::new(lang::tr(&self.lang, "export_pgn"))).padding(5).on_press(PuzzleMessage::ExportToPGN),
             ].padding([0, 30]).spacing(10).align_x(Alignment::Center))
         } else {
             Scrollable::new(col![

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -127,7 +127,8 @@ impl SettingsTab {
                     self.export_pgs = String::from("0");
                 }
                 Task::none()
-            } SettingsMessage::ChangePressed => {
+            },
+            SettingsMessage::ChangePressed => {
                 let engine_path = if self.engine_path.is_empty() {
                     None
                 } else {

--- a/translations/en-US/ocp.ftl
+++ b/translations/en-US/ocp.ftl
@@ -78,6 +78,7 @@ show_coords = Show coordinates:
 pdf_number_of_pages = No. of pages to export to PDF:
 get_first_puzzles1 = Get the first
 get_first_puzzles2 =  {" "}puzzles
+export_pgn = Export current puzzles as PGN
 engine_path = Engine path (with .exe name):
 save = Save Changes
 settings_saved = Settings saved!

--- a/translations/es/ocp.ftl
+++ b/translations/es/ocp.ftl
@@ -78,6 +78,7 @@ show_coords = Coordenadas del tablero:
 pdf_number_of_pages = N. de páginas para exportar en PDF:
 get_first_puzzles1 = Obtener los primeros
 get_first_puzzles2 =  {" "}ejercícios
+export_pgn = Exportar ejercicios actuales a PGN
 engine_path = Camino del motor de ajedrez (con el nombre del .exe):
 save = Guardar Cambios
 settings_saved = Preferencias guardadas!

--- a/translations/fr/ocp.ftl
+++ b/translations/fr/ocp.ftl
@@ -80,6 +80,7 @@ show_coords = Montrer les coordonnées:
 pdf_number_of_pages = Limite de pages pour le PDF:
 get_first_puzzles1 = Accéder aux
 get_first_puzzles2 = {" "}premiers puzzles
+export_pgn = Exporter les puzzles actuels en PGN
 engine_path = Chemin d'accès du moteur (avec le nom du fichier .exe):
 save = Enregistrer les modifications
 settings_saved = Paramètres enregistrés !

--- a/translations/pt-BR/ocp.ftl
+++ b/translations/pt-BR/ocp.ftl
@@ -78,6 +78,7 @@ show_coords = Coordenadas do tabuleiro:
 pdf_number_of_pages = N. de pags. para exportar em PDF:
 get_first_puzzles1 = Obter os primeiros
 get_first_puzzles2 =  {" "}problemas
+export_pgn = Exportar problemas atuais para PGN
 engine_path = Caminho para a engine (com o .exe):
 save = Salvar Mudanças
 settings_saved = Configurações salvas!


### PR DESCRIPTION
### Adds PGN export, fixes #37


<img width="500" height="466" alt="export_pull_request_offline_lichess_puzzles" width="50%" src="https://github.com/user-attachments/assets/a45d7b4d-7693-4770-ac2f-5bab42af4950" />

### Example export File:
[test.zip](https://github.com/user-attachments/files/21922086/test.zip)


# How to use it:

1. Add some filters in search. Run "Export Current Puzzles as PGN" (Or you can use this test file [test.zip](https://github.com/user-attachments/files/21922086/test.zip), it contains an example export)
2. Download anki
3. Install the "TowelSniffer/Anki-Chess-2.0/" Template  (https://ankiweb.net/shared/info/1300975327?cb=1755601119118)
4. Install PGN import addon in anki https://ankiweb.net/shared/info/569467423 (Tools -> Addons -> Enter code 569467423)
5. Then import:
<img width="320" height="381" alt="screenshot_anki_import" src="https://github.com/user-attachments/assets/09b5f9a1-ef59-4bf8-a8df-3fb29bc8a530" />


6. 🎉
<img width="671" height="602" alt="Screenshot 2025-08-21 at 20 37 01" src="https://github.com/user-attachments/assets/fbf05b58-4f43-4d26-a94a-a0967620386f" />

## Notes

There’s an unmerged pull request in the chess crate (https://github.com/jordanbray/chess/pull/71/files) that appears to add PGN generation. My own PGN generation function might still be a bit rough around the edges. A thing to consider.